### PR TITLE
Add check for project path

### DIFF
--- a/lib/codealike-atom.js
+++ b/lib/codealike-atom.js
@@ -71,6 +71,12 @@ const AtomCodealikePlugin = {
     if (atom.project.rootDirectories.length) {
       // then ensure codealike configuration exists
       // and start tracking
+
+      let atomProject = atom.project.rootDirectories["0"].lowerCasePath;
+      if (!atomProject) {
+        atomProject = atom.project.rootDirectories["0"].path;
+      }
+
       Codealike
         .configure(atom.project.rootDirectories["0"].lowerCasePath)
         .then(

--- a/lib/codealike-atom.js
+++ b/lib/codealike-atom.js
@@ -67,18 +67,16 @@ const AtomCodealikePlugin = {
   },
 
   startTrackingProject() {
+    let paths = atom.project.getPaths();
+
     // verify if there is a loaded folder in workspace
-    if (atom.project.rootDirectories.length) {
+    if (paths.length) {
       // then ensure codealike configuration exists
       // and start tracking
-
-      let atomProject = atom.project.rootDirectories["0"].lowerCasePath;
-      if (!atomProject) {
-        atomProject = atom.project.rootDirectories["0"].path;
-      }
+      let rootPath = paths[0];
 
       Codealike
-        .configure(atom.project.rootDirectories["0"].lowerCasePath)
+        .configure(rootPath)
         .then(
           (configuration) => {
             // calculate when workspace started loading


### PR DESCRIPTION
Hi.

I'm using Codealike to have a way to track my personal work time and I'm working with two computers : one with Windows 10 and another one with Manjaro (Arch Linux).

The problem is when i want to work on my Manjaro, the codealike package isn't working.

In the package, to configure the project inside Codealike (if I understand), you tried to get the `atom.project.rootDirectories["0"].lowerCasePath` but I've found that there's no `lowerCasePath` attribute : 

![before_fix](https://user-images.githubusercontent.com/1726412/52297930-1a957300-2982-11e9-983f-debb17436d5c.png)

This pull request add the condition to check if we have the `lowerCasePath` attribute and if we not, we put the `path` one.

After doing the check I've got this : 

![after_fix](https://user-images.githubusercontent.com/1726412/52297987-339e2400-2982-11e9-80d9-85b1c115c46c.png)

As you can see, the package has the `Codealike is tracking on-line`.

I haven't tested on Mac since I do not own one.
